### PR TITLE
rc not optional in datamode_generic_init_pointers

### DIFF
--- a/dshr/dshr_generic_mod.F90
+++ b/dshr/dshr_generic_mod.F90
@@ -65,13 +65,13 @@ contains
   subroutine datamode_generic_init_pointers(exportState, sdat, rc)
     type(ESMF_State),       intent(inout) :: exportState
     type(shr_strdata_type), intent(in)    :: sdat
-    integer,                intent(out), optional :: rc
+    integer,                intent(out),  :: rc
 
     integer :: i, n, total_vars, cache_idx
     character(len=CL) :: fieldName
     character(len=CL) :: logMsg
 
-    if (present(rc)) rc = ESMF_SUCCESS
+    rc = ESMF_SUCCESS
 
     ! 1. Count the total number of fields to allocate the cache
     total_vars = 0


### PR DESCRIPTION
### Description of changes

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

